### PR TITLE
Fix formatting of GLOSSARY.md.

### DIFF
--- a/tutorials/GLOSSARY.md
+++ b/tutorials/GLOSSARY.md
@@ -1,54 +1,57 @@
+| [Back: Interacting With `git`, And How To Contribute Your Work To The Repo](/tutorials/git_Interactions.md) | [Main Table Of Contents](tutorials/TABLE_OF_CONTENTS.md) | [Next: External References And Resources](/tutorials/EXTERNAL_REFERENCES_AND_RESOURCES.md) |
+| :-: | :-: | :-: |
+
 # GLOSSARY:
-These are short definitions of words that may not be familiar to beginners.  It’s always growing and expanding.  Either open an issue to request more words or tell the author that some definition could be improved.  Or better yet, please make a pull request if you wish to add more yourself or improve something yourself. ^_^
+These are short definitions of words that may not be familiar to beginners.  It's always growing and expanding.  Either open an issue to request more words or tell the author that some definition could be improved.  Or better yet, please make a pull request if you wish to add more yourself or improve something yourself. ^_^
 
-* branching = the ability of a VCS that allows each person in a project to work on a separate version of a repository that doesn’t affect the main repo or the other users.  In other words, you can mess around with this as much as you want, with no fear that any mistakes will affect others.
+* branching = the ability of a VCS that allows each person in a project to work on a separate version of a repository that doesn't affect the main repo or the other users.  In other words, you can mess around with this as much as you want, with no fear that any mistakes will affect others.
 
-* CLI, cli = initialism of “command line interface”.
+* CLI, cli = initialism of "command line interface".
 
 * clone, to clone, cloning = the process of downloading a copy of a remote repo into your local machine.
 
 * command line interface = a user interface that uses the command line, where the way to view and edit everything is by typing commands of text.  The opposite of a graphic user interface (GUI).
 
-* directory = official name of a “folder” in your computer.
+* directory = official name of a "folder" in your computer.
 
-* external repo = someplace to store the backup of a project that is using version control.  Usually, this is external from your local machine, in a server that’s either handled by your administrator or an external service like GitLab or GitHub.  
+* external repo = someplace to store the backup of a project that is using version control.  Usually, this is external from your local machine, in a server that's either handled by your administrator or an external service like GitLab or GitHub.  
 
 * `git` = an open source implementation of a version control system that allows branching and collaboration.
 
 * git bash = a git client that uses the bash command line interface.  This is how someone accesses the git version control system.
 
-* `git lfs` = git add-on that has the capability to work with “large files”, AKA files that are larger than 100MB.  LFS is the initialism of “Large File System”.
+* `git lfs` = git add-on that has the capability to work with "large files", AKA files that are larger than 100MB.  LFS is the initialism of "Large File System".
 
-* GUI, gui = stands for “Graphic User Interface”.  Can be treated as an initialism (pronounced as the letters G-U-I), but more often treated as an acronym (pronounced like the word “gooey”).
+* GUI, gui = stands for "Graphic User Interface".  Can be treated as an initialism (pronounced as the letters G-U-I), but more often treated as an acronym (pronounced like the word "gooey").
 
 * graphic user interface = a user interface that relies heavily on graphics and is more often than not controlled with a cursor or a mouse or a stylus, etc.; although there are still parts where users type with their keyboard.  The opposite of a command line interface (CLI).
 
-* LFS, lfs = initialism that means “Large File System.”
+* LFS, lfs = initialism that means "Large File System."
 
 * local machine = your computer (desktop/laptop) or workstation.
 
 * master branch, master = the main branch of a repo.
 
-* repo = abbreviation of “repository”.
+* repo = abbreviation of "repository".
 
 * repository = where a git-initialized project is stored.
 
 * tab-completion, tab-complete = using the `Tab` key on your keyboard while in the command line can help with completing words.
 
-* UI, ui = stands for “user interface”.  Treated as an initialism (pronounced as the letters U-I).
+* UI, ui = stands for "user interface".  Treated as an initialism (pronounced as the letters U-I).
 
 * unified resource locator = the address of a specific webpage or file on the Internet.  See here for more information: https://techterms.com/definition/url & https://en.wikipedia.org/wiki/URL
 
-* URL, url = stands for “Unified Resource Locator”.  Sometimes, treated as an initialism (pronounced as the letters U-R-L), but I’ve heard it treated as an acronym (pronounced like “yu-ral”).
+* URL, url = stands for "Unified Resource Locator".  Sometimes, treated as an initialism (pronounced as the letters U-R-L), but I've heard it treated as an acronym (pronounced like "YU-ral").
 
 * user interface = the way that a user interacts or interfaces with something.  Shortened as UI or ui.
 
-* VCS, vcs = initialism of “version control system”.
+* VCS, vcs = initialism of "version control system".
 
-* version control = the ability of making backups or versions of one’s work, with the option of going back to an older version if necessary.
+* version control = the ability of making backups or versions of one's work, with the option of going back to an older version if necessary.
 
 * version control system = a system that implements the concept of version control.  Shortened as VCS or vcs.
 
 
-| [Back: Interacting With `git`, And How To Contribute Your Work To The Repo](/tutorials/git_Interactions.md) | [Table Of Contents](tutorials/TABLE_OF_CONTENTS.md) | [Next: External References And Resources](/tutorials/EXTERNAL_REFERENCES_AND_RESOURCES.md) |
+| [Back: Interacting With `git`, And How To Contribute Your Work To The Repo](/tutorials/git_Interactions.md) | [Main Table Of Contents](tutorials/TABLE_OF_CONTENTS.md) | [Next: External References And Resources](/tutorials/EXTERNAL_REFERENCES_AND_RESOURCES.md) |
 | :-: | :-: | :-: |


### PR DESCRIPTION
- Differentiate between the page's table of contents vs the main table of contents. (Specify that the table of contents in the link is the main large one.)
- Add header with the navigation links.
- Replace ‘ & ’ with '; and “ & ” with " (basically change the stylized versions with the more web-friendly versions of apostrophe and quotation marks).